### PR TITLE
Added yojson <2.0.0 dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OCAML_COMPILER ?= $(shell opam switch list | grep -m 1 -oe "ocaml-system[^ ]*")
 
 _opam:
 	opam switch create . $(OCAML_COMPILER) --no-install
-	opam install tuareg merlin user-setup unisim_archisec mmap -y
+	opam install "yojson<2.0.0" tuareg merlin user-setup unisim_archisec mmap -y
 	opam user-setup install
 	opam pin add . -n
 	opam install binsec --deps-only --with-test --with-doc -y


### PR DESCRIPTION
Merlin currently has a constraint issue on the yojson dependency (see [merlin issue 1478](https://github.com/ocaml/merlin/issues/1478 )), which means that installing merlin will always fail, and hence, so will this package. This means that binsec/rel is currently uninstallable (at least without using the docker image).

Until that is solved, I manually added the yojson<2.0.0 dependency and the installation now works.